### PR TITLE
Use short git SHA in application metrics

### DIFF
--- a/lib/miniapp/prom_ex.ex
+++ b/lib/miniapp/prom_ex.ex
@@ -81,7 +81,8 @@ defmodule Miniapp.PromEx do
 
   @doc false
   def git_sha do
-    read_git_meta_file("/etc/git_sha") || System.get_env("GIT_SHA") || "unknown"
+    sha = read_git_meta_file("/etc/git_sha") || System.get_env("GIT_SHA") || "unknown"
+    if sha != "unknown", do: String.slice(sha, 0, 7), else: sha
   end
 
   @doc false


### PR DESCRIPTION
## Summary
• Modified the `git_sha/0` function in `lib/miniapp/prom_ex.ex` to return the first 7 characters of the git SHA instead of the full long SHA
• Preserves the `git_author/0` function unchanged to avoid truncating author names
• Application now displays more readable short SHAs in metrics while maintaining all functionality

## Test plan
- [ ] Verify application starts successfully
- [ ] Check that metrics endpoint shows short SHA format
- [ ] Confirm author information remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)