### PR TITLE
Fix unused variable warning in WalletLive

### DIFF
--- a/lib/miniapp_web/live/wallet.ex
+++ b/lib/miniapp_web/live/wallet.ex
@@ -48,7 +48,7 @@ defmodule MiniappWeb.WalletLive do
   def handle_event(
         "get_capabilities",
         _params,
-        %{assigns: %{connected_address: connected_address}} = socket
+        %{assigns: %{connected_address: _connected_address}} = socket
       ) do
     {:noreply, socket |> push_event("client:request", %{action: "get_capabilities"})}
   end


### PR DESCRIPTION
## Summary
- Fix unused variable compilation warning in `MiniappWeb.WalletLive.handle_event/3`
- Prefix unused `connected_address` variable with underscore to follow Elixir conventions

## Test plan
- [x] Run `mix compile --warnings-as-errors` to verify no warnings
- [x] Verify application still compiles successfully

🤖 Generated with [Claude Code](https://claude.ai/code)