### PR TITLE
Revert network from baseSepolia to base

### DIFF
--- a/assets/js/minikit-hook/index.js
+++ b/assets/js/minikit-hook/index.js
@@ -1,15 +1,15 @@
 import { sdk } from "@farcaster/miniapp-sdk";
 import { http, createConfig } from "@wagmi/core";
-import { baseSepolia } from "@wagmi/core/chains";
+import { base } from "@wagmi/core/chains";
 import { farcasterMiniApp as miniAppConnector } from "@farcaster/miniapp-wagmi-connector";
 import { createClientRequestHandler } from "./dispatcher";
 
 const config = createConfig({
   connectors: [miniAppConnector()],
   transports: {
-    [baseSepolia.id]: http(),
+    [base.id]: http(),
   },
-  chains: [baseSepolia],
+  chains: [base],
 });
 
 /**


### PR DESCRIPTION
## Summary
- Reverted network configuration from baseSepolia to base in minikit hook
- Updated imports and chain configuration for production deployment

## Test plan
- [ ] Verify network connection works with base chain
- [ ] Test minikit functionality with base network

🤖 Generated with [Claude Code](https://claude.ai/code)