### PR TITLE
Handle nested send_calls response structure

### DIFF
--- a/lib/miniapp_web/live/wallet.ex
+++ b/lib/miniapp_web/live/wallet.ex
@@ -48,7 +48,7 @@ defmodule MiniappWeb.WalletLive do
   def handle_event(
         "get_capabilities",
         _params,
-        %{assigns: %{connected_address: connected_address}} = socket
+        %{assigns: %{connected_address: _connected_address}} = socket
       ) do
     {:noreply, socket |> push_event("client:request", %{action: "get_capabilities"})}
   end
@@ -101,6 +101,21 @@ defmodule MiniappWeb.WalletLive do
 
     Logger.info("get_capabilities completed with capabilities: #{inspect(new_caps)}")
     {:noreply, socket |> assign(:capabilities, new_caps)}
+  end
+
+  @impl true
+  def handle_event(
+        "client:response",
+        %{"action" => "send_calls", "ok" => true, "result" => %{"response" => %{"id" => id}}},
+        socket
+      ) do
+    case socket.assigns[:connected_address] do
+      nil -> 
+        Logger.info("send_calls completed with id: #{id}")
+      wallet_address ->
+        Logger.info("Calls sent successfully - ID: #{id}, Wallet: #{wallet_address}")
+    end
+    {:noreply, socket}
   end
 
   @impl true

--- a/test/miniapp_web/live/wallet_live_test.exs
+++ b/test/miniapp_web/live/wallet_live_test.exs
@@ -185,6 +185,35 @@ defmodule MiniappWeb.WalletLiveTest do
       assert render(view)
     end
 
+    test "handles successful send_calls response with nested structure", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "/embed/wallet")
+      
+      # First connect a wallet
+      view
+      |> render_hook("client:response", %{
+        "action" => "get_account",
+        "ok" => true,
+        "result" => %{"address" => "0x123abc"}
+      })
+      
+      # Send the nested send_calls response event using the exact structure from the error
+      view
+      |> render_hook("client:response", %{
+        "action" => "send_calls",
+        "id" => nil,
+        "ok" => true,
+        "result" => %{
+          "response" => %{
+            "capabilities" => %{},
+            "id" => "0x99e500b869bb652e439908089ccfd6fc24f9c4a8a1d3b8152660d8f26cb0265c"
+          }
+        }
+      })
+      
+      # Should handle without error
+      assert render(view)
+    end
+
     test "handles failed transaction response", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/embed/wallet")
       


### PR DESCRIPTION
## Summary
- Fix unhandled event warning for `client:response` with `action: "send_calls"` that contains nested response structure
- Add informative logging that includes both transaction ID and wallet address when calls are sent successfully
- Add comprehensive test case using the exact error structure from production logs

## Test plan
- [x] Added test case that reproduces the exact unhandled event structure
- [x] Verified all existing wallet tests continue to pass
- [x] Confirmed no compilation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)